### PR TITLE
core: sysprop: Use 'release-keys' for build tag

### DIFF
--- a/core/sysprop.mk
+++ b/core/sysprop.mk
@@ -153,7 +153,7 @@ endif
 ifeq ($(DEFAULT_SYSTEM_DEV_CERTIFICATE),build/make/target/product/security/testkey)
 BUILD_KEYS := test-keys
 else
-BUILD_KEYS := dev-keys
+BUILD_KEYS := release-keys
 endif
 BUILD_VERSION_TAGS += $(BUILD_KEYS)
 BUILD_VERSION_TAGS := $(subst $(space),$(comma),$(sort $(BUILD_VERSION_TAGS)))


### PR DESCRIPTION
Some apps may check for this.

[kubersharma001]:
- Adapt to android-12.0

Change-Id: Ibece80d0e6020efaf886d8d5f72290fa6740df7d